### PR TITLE
feat(Global): start MarketingCloud SDK on startup

### DIFF
--- a/android/src/main/java/co/work/react_native_sfmobilepush/SFMobilePushInitializer.java
+++ b/android/src/main/java/co/work/react_native_sfmobilepush/SFMobilePushInitializer.java
@@ -1,0 +1,93 @@
+package co.work.react_native_sfmobilepush;
+
+import android.app.Application;
+import android.app.NotificationChannel;
+import android.app.PendingIntent;
+import android.content.Context;
+import android.content.Intent;
+import android.content.res.Resources;
+import android.graphics.Bitmap;
+import android.graphics.BitmapFactory;
+import android.os.Build;
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.v4.app.NotificationCompat;
+
+import com.salesforce.marketingcloud.InitializationStatus;
+import com.salesforce.marketingcloud.MarketingCloudConfig;
+import com.salesforce.marketingcloud.MarketingCloudSdk;
+import com.salesforce.marketingcloud.notifications.NotificationCustomizationOptions;
+import com.salesforce.marketingcloud.notifications.NotificationManager;
+import com.salesforce.marketingcloud.notifications.NotificationMessage;
+
+import java.util.Map;
+import java.util.Random;
+
+public class SFMobilePushInitializer {
+
+
+    private static String createNotificationChannel(Application application, String channelId, String channelName) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            NotificationChannel channel = new NotificationChannel(channelId, channelName, android.app.NotificationManager.IMPORTANCE_DEFAULT);
+            android.app.NotificationManager notificationManager = application.getSystemService(android.app.NotificationManager.class);
+            notificationManager.createNotificationChannel(channel);
+        }
+        return channelId;
+    }
+
+    public static void init(final Class mainActivity, Application application, String applicationId, String accessToken, String senderId, String channelName, String configChannelId) {
+        final String packageName = application.getPackageName();
+        final Resources resources = application.getResources();
+        final String channelId = configChannelId != null ? createNotificationChannel(application, configChannelId, channelName) : NotificationManager.createDefaultNotificationChannel(application);
+
+        final int smallIconId = resources.getIdentifier("ic_notification", "mipmap", packageName);
+
+        final int largeIconId = resources.getIdentifier("ic_launcher", "mipmap", packageName);
+        final Bitmap largeIconBitmap = BitmapFactory.decodeResource(resources, largeIconId);
+
+        final NotificationManager.NotificationBuilder notificationBuilder = new NotificationManager.NotificationBuilder() {
+            @Override
+            public NotificationCompat.Builder setupNotificationBuilder(@NonNull Context context, @NonNull NotificationMessage notificationMessage) {
+                NotificationCompat.Builder builder =
+                        NotificationManager.getDefaultNotificationBuilder(context, notificationMessage, channelId, smallIconId);
+                builder.setLargeIcon(largeIconBitmap);
+
+                Bundle bundle = new Bundle();
+                bundle.putBoolean(SFMobilePushModule.SF_BUNDLE_IDENTIFIER, true);
+                for (Map.Entry<String, String> entry : notificationMessage.payload().entrySet()) {
+                    bundle.putString(entry.getKey(), entry.getValue());
+                }
+
+                Intent intent = new Intent(context, mainActivity);
+                intent.putExtras(bundle);
+                PendingIntent pendingIntent = PendingIntent.getActivity(context, new Random().nextInt(), intent,
+                        PendingIntent.FLAG_UPDATE_CURRENT);
+
+                PendingIntent contentIntent = NotificationManager.redirectIntentForAnalytics(context, pendingIntent, notificationMessage, true);
+                builder.setContentIntent(contentIntent);
+                return builder;
+            }
+        };
+
+        final NotificationCustomizationOptions customizationOptions = NotificationCustomizationOptions.create(notificationBuilder);
+
+        final MarketingCloudConfig config =
+                MarketingCloudConfig
+                        .builder()
+                        .setApplicationId(applicationId)
+                        .setAccessToken(accessToken)
+                        .setSenderId(senderId)
+                        .setNotificationCustomizationOptions(customizationOptions)
+                        .build(application);
+
+        final MarketingCloudSdk.InitializationListener listener = new MarketingCloudSdk.InitializationListener() {
+            @Override
+            public void complete(@NonNull InitializationStatus initializationStatus) {
+            }
+        };
+
+
+        MarketingCloudSdk.init(application, config, listener);
+    }
+}
+}

--- a/android/src/main/java/co/work/react_native_sfmobilepush/SFMobilePushModule.java
+++ b/android/src/main/java/co/work/react_native_sfmobilepush/SFMobilePushModule.java
@@ -1,58 +1,38 @@
 package co.work.react_native_sfmobilepush;
 
 import android.app.Activity;
-import android.app.Application;
-import android.app.NotificationChannel;
-import android.app.PendingIntent;
-import android.content.Context;
 import android.content.Intent;
-import android.content.res.Resources;
-import android.graphics.Bitmap;
-import android.graphics.BitmapFactory;
 import android.os.Build;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
-import android.support.v4.app.NotificationCompat;
 import android.support.v4.app.NotificationManagerCompat;
 
 import com.facebook.react.bridge.ActivityEventListener;
-import com.facebook.react.bridge.NoSuchKeyException;
 import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReactContextBaseJavaModule;
 import com.facebook.react.bridge.ReactMethod;
-import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableArray;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.bridge.WritableNativeArray;
 import com.facebook.react.bridge.WritableNativeMap;
 import com.facebook.react.modules.core.DeviceEventManagerModule;
-import com.salesforce.marketingcloud.InitializationStatus;
-import com.salesforce.marketingcloud.MarketingCloudConfig;
 import com.salesforce.marketingcloud.MarketingCloudSdk;
-import com.salesforce.marketingcloud.notifications.NotificationCustomizationOptions;
-import com.salesforce.marketingcloud.notifications.NotificationManager;
-import com.salesforce.marketingcloud.notifications.NotificationMessage;
 
 import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Random;
 import java.util.Set;
 
 public class SFMobilePushModule extends ReactContextBaseJavaModule implements ActivityEventListener {
     static public final String SF_BUNDLE_IDENTIFIER = "SF_BUNDLE_IDENTIFIER";
     static public final String EVENT_SF_NOTIFICATION = "SFMobilePushNotificationReceived";
 
-    private final Application application;
-    private boolean isInitialized = false;
-
-    public SFMobilePushModule(ReactApplicationContext reactContext, Application application) {
+    public SFMobilePushModule(ReactApplicationContext reactContext) {
         super(reactContext);
-        this.application = application;
         reactContext.addActivityEventListener(this);
     }
 
@@ -114,127 +94,12 @@ public class SFMobilePushModule extends ReactContextBaseJavaModule implements Ac
         //Do nothing. This method is required to comply with ActivityEventListener
     }
 
-    public Class getMainActivityClass() {
-        String packageName = application.getPackageName();
-        Intent launchIntent = application.getPackageManager().getLaunchIntentForPackage(packageName);
-        String className = launchIntent.getComponent().getClassName();
-        try {
-            return Class.forName(className);
-        } catch (ClassNotFoundException e) {
-            e.printStackTrace();
-            return null;
-        }
-    }
-
     @ReactMethod
     public void checkPermissions(Promise promise) {
         try {
             ReactContext reactContext = getReactApplicationContext();
             NotificationManagerCompat managerCompat = NotificationManagerCompat.from(reactContext);
             promise.resolve(managerCompat.areNotificationsEnabled());
-        } catch (Exception e) {
-            promise.reject(e);
-        }
-    }
-
-    private String getStringOrNull(ReadableMap map, String key) {
-        try {
-            return map.getString(key);
-        } catch (NoSuchKeyException e) {
-            return null;
-        }
-    }
-
-    private String createNotificationChannel(String channelId, String channelName) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            NotificationChannel channel = new NotificationChannel(channelId, channelName, android.app.NotificationManager.IMPORTANCE_DEFAULT);
-            android.app.NotificationManager notificationManager = this.application.getSystemService(android.app.NotificationManager.class);
-            notificationManager.createNotificationChannel(channel);
-        }
-        return channelId;
-    }
-
-    @ReactMethod
-    public void init(ReadableMap arguments, final Promise promise) {
-        if (isInitialized) {
-            promise.resolve(null);
-            return;
-        }
-        final String applicationId = getStringOrNull(arguments, "appId");
-        final String accessToken = getStringOrNull(arguments, "accessToken");
-        final String senderId = getStringOrNull(arguments, "senderId");
-        final String channelName = getStringOrNull(arguments, "channelName");
-        final String configChannelId = getStringOrNull(arguments, "channelId");
-        final String channelId = configChannelId != null ? createNotificationChannel(configChannelId, channelName) : NotificationManager.createDefaultNotificationChannel(this.application);
-        final String smallIcon = getStringOrNull(arguments, "smallIcon");
-        final String largeIcon = getStringOrNull(arguments, "largeIcon");
-
-        try {
-            String packageName = getReactApplicationContext().getPackageName();
-            final Resources resources = getReactApplicationContext().getResources();
-
-            final int smallIconId;
-            if (smallIcon != null) {
-                smallIconId = resources.getIdentifier(smallIcon, "mipmap", packageName);
-            } else {
-                smallIconId = resources.getIdentifier("ic_notification", "mipmap", packageName);
-            }
-
-            final int largeIconId;
-            if (largeIcon != null) {
-                largeIconId = resources.getIdentifier(largeIcon, "mipmap", packageName);
-            } else {
-                largeIconId = resources.getIdentifier("ic_launcher", "mipmap", packageName);
-            }
-            final Bitmap largeIconBitmap = BitmapFactory.decodeResource(resources, largeIconId);
-            final NotificationManager.NotificationBuilder notificationBuilder = new NotificationManager.NotificationBuilder() {
-                @Override
-                public NotificationCompat.Builder setupNotificationBuilder(@NonNull Context context, @NonNull NotificationMessage notificationMessage) {
-                    NotificationCompat.Builder builder =
-                            NotificationManager.getDefaultNotificationBuilder(context, notificationMessage, channelId, smallIconId);
-                    builder.setLargeIcon(largeIconBitmap);
-
-                    Bundle bundle = new Bundle();
-                    bundle.putBoolean(SF_BUNDLE_IDENTIFIER, true);
-                    for (Map.Entry<String, String> entry : notificationMessage.payload().entrySet()) {
-                        bundle.putString(entry.getKey(), entry.getValue());
-                    }
-
-                    Intent intent = new Intent(context, getMainActivityClass());
-                    intent.putExtras(bundle);
-                    PendingIntent pendingIntent = PendingIntent.getActivity(context, new Random().nextInt(), intent,
-                            PendingIntent.FLAG_UPDATE_CURRENT);
-
-                    PendingIntent contentIntent = NotificationManager.redirectIntentForAnalytics(context, pendingIntent, notificationMessage, true);
-                    builder.setContentIntent(contentIntent);
-                    return builder;
-                }
-            };
-
-            final NotificationCustomizationOptions customizationOptions = NotificationCustomizationOptions.create(notificationBuilder);
-
-            final MarketingCloudConfig config =
-                    MarketingCloudConfig
-                            .builder()
-                            .setApplicationId(applicationId)
-                            .setAccessToken(accessToken)
-                            .setSenderId(senderId)
-                            .setNotificationCustomizationOptions(customizationOptions)
-                            .build(this.application);
-
-            final MarketingCloudSdk.InitializationListener listener = new MarketingCloudSdk.InitializationListener() {
-                @Override
-                public void complete(@NonNull InitializationStatus initializationStatus) {
-                    if (initializationStatus.isUsable()) {
-                        promise.resolve(null);
-                    } else {
-                        promise.reject(new Exception("SFMobilePush could not be initialized"));
-                    }
-                }
-            };
-
-
-            MarketingCloudSdk.init(this.application, config, listener);
         } catch (Exception e) {
             promise.reject(e);
         }

--- a/android/src/main/java/co/work/react_native_sfmobilepush/SFMobilePushPackage.java
+++ b/android/src/main/java/co/work/react_native_sfmobilepush/SFMobilePushPackage.java
@@ -1,9 +1,6 @@
 package co.work.react_native_sfmobilepush;
 
-import android.app.Application;
-
 import com.facebook.react.ReactPackage;
-import com.facebook.react.bridge.JavaScriptModule;
 import com.facebook.react.bridge.NativeModule;
 import com.facebook.react.bridge.ReactApplicationContext;
 import com.facebook.react.uimanager.ViewManager;
@@ -14,12 +11,6 @@ import java.util.List;
 
 public class SFMobilePushPackage implements ReactPackage {
 
-    private final Application application;
-
-    public SFMobilePushPackage(Application application) {
-        this.application = application;
-    }
-
     @Override
     public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
         return Collections.emptyList();
@@ -29,7 +20,7 @@ public class SFMobilePushPackage implements ReactPackage {
     public List<NativeModule> createNativeModules(
             ReactApplicationContext reactContext) {
         List<NativeModule> modules = new ArrayList<>();
-        modules.add(new SFMobilePushModule(reactContext, application));
+        modules.add(new SFMobilePushModule(reactContext));
         return modules;
     }
 }

--- a/ios/react-native-sfmobilepush/SFMobilePush.h
+++ b/ios/react-native-sfmobilepush/SFMobilePush.h
@@ -4,7 +4,10 @@
 
 @interface SFMobilePush : RCTEventEmitter <RCTBridgeModule>
 
++ (void)initialize:(NSString *) applicationId accessToken:(NSString *) accessToken;
 + (void)didReceiveRemoteNotification:(UNNotificationResponse *) response;
++ (void)didRegisterForRemoteNotificationsWithDeviceToken:(NSData *)deviceToken;
++ (void)didReceiveRemoteNotificationUserInfo:(NSDictionary *) userInfo;
 - (void)handleRemoteNotification:(NSNotification *) notification;
 - (NSURL*) getConfigPath;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-sfmobilepush",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Salesforce Jorney Builder wrapper for react-native",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
Instead of initializing the MC SDK when the init function is ran on the
JS layer the SDK should be initialized on the app startup (onCreate and
didFinishLaunchingWithOptions). That way the notification will more
reliable arrive when running on background