### PR TITLE
fix(Android): check for initial notification before adding listener

### DIFF
--- a/android/src/main/java/co/work/react_native_sfmobilepush/SFMobilePushModule.java
+++ b/android/src/main/java/co/work/react_native_sfmobilepush/SFMobilePushModule.java
@@ -95,6 +95,19 @@ public class SFMobilePushModule extends ReactContextBaseJavaModule implements Ac
     }
 
     @ReactMethod
+    public void getInitialNotification(Promise promise) {
+        try {
+            Activity activity = getCurrentActivity();
+            Bundle bundle = activity.getIntent().getExtras();
+            if (bundle != null && bundle.getBoolean(SF_BUNDLE_IDENTIFIER)) {
+                promise.resolve(bundleToJsonString(bundle));
+            }
+        } catch (Exception e) {
+            promise.reject(e);
+        }
+    }
+
+    @ReactMethod
     public void checkPermissions(Promise promise) {
         try {
             ReactContext reactContext = getReactApplicationContext();

--- a/index.js
+++ b/index.js
@@ -22,8 +22,12 @@ const convertListener = listener => event =>
 
 const notificationEmitter = new NativeEventEmitter(SFMobilePush);
 
-const registerNotificationHandler = listener => 
-  notificationEmitter.addListener(SFMobilePush.notificationEvent, convertListener(listener))
+const registerNotificationHandler = listener => {
+  if (!isIOS) {
+    SFMobilePush.getInitialNotification().then(convertListener(listener));
+  }
+  return notificationEmitter.addListener(SFMobilePush.notificationEvent, convertListener(listener))
+}
 
 const promiseIOSCheckPermissions = () =>
   new Promise(resolve => {


### PR DESCRIPTION
When a salesforce notification comes and the Android app is closed, the
notification takes the user directly to the Home Screen and doesn't even
arrive to the `didReceiveSFNotification` saga.
In order to fix that, it's necessary to check for an initial notification
before adding the listener to `notificationEmitter`.