### PR TITLE
fix(iOS): requiresMainQueueSetup not defined

### DIFF
--- a/ios/react-native-sfmobilepush/SFMobilePush.m
+++ b/ios/react-native-sfmobilepush/SFMobilePush.m
@@ -29,6 +29,11 @@ RCT_EXPORT_MODULE(SFMobilePush)
     return @{ @"notificationEvent": EVENT_SF_NOTIFICATION };
 }
 
++ (BOOL)requiresMainQueueSetup
+{
+    return NO;
+}
+
 + (void)didReceiveRemoteNotification:(UNNotificationResponse *) response
 {
     [[MarketingCloudSDK sharedInstance] sfmc_setNotificationRequest:response.notification.request];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-sfmobilepush",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Salesforce Jorney Builder wrapper for react-native",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
this patch defines requiresMainQueueSetup to avoid a warning on app
startup